### PR TITLE
Required for the ConfigArgParse changes in aca-py

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -20,6 +20,7 @@ LABEL summary="$SUMMARY" \
     version="$tag_version" \
     maintainer=""
 
-RUN pip install --no-cache-dir aries-cloudagent==${agent_version}
+# RUN pip install --no-cache-dir aries-cloudagent==${agent_version}
+RUN pip install --no-cache-dir git+https://github.com/ianco/aries-cloudagent-python.git#egg=aries-cloudagent
 
 ENTRYPOINT ["/bin/bash", "-c", "aca-py \"$@\"", "--"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -20,7 +20,7 @@ LABEL summary="$SUMMARY" \
     version="$tag_version" \
     maintainer=""
 
-# RUN pip install --no-cache-dir aries-cloudagent==${agent_version}
-RUN pip install --no-cache-dir git+https://github.com/ianco/aries-cloudagent-python.git#egg=aries-cloudagent
+RUN pip install --no-cache-dir git+https://github.com/ianco/ConfigArgParse.git#egg=ConfigArgParse
+RUN pip install --no-cache-dir aries-cloudagent==${agent_version}
 
 ENTRYPOINT ["/bin/bash", "-c", "aca-py \"$@\"", "--"]


### PR DESCRIPTION
Explicitly install ConfigArgParse from ianco fork

(setup.py doesn't support install from git repositores, so there was a corresponding change in aca-py that filters out this library in setup)
