### PR TITLE
Added tag for 0.7.4 and removed all rc tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,9 @@ By default, the tag for a new image will be composed by `$base_image_tag`, follo
 | py36-1.15-1_0.6.0 | python         | von-image:py36-1.15-1 | 0.6.0            |
 | py36-1.16-1_0.7.0 | python         | von-image:py36-1.16-1 | 0.7.0            |
 | py36-1.16-1_0.7.1 | python         | von-image:py36-1.16-1 | 0.7.1            |
-| py36-1.16-1_0.7.2-rc0 | python     | von-image:py36-1.16-1 | 0.7.2-rc0        |
 | py36-1.16-1_0.7.2 | python         | von-image:py36-1.16-1 | 0.7.2            |
-| py36-1.16-1_0.7.3-rc0 | python     | von-image:py36-1.16-1 | 0.7.3-rc0        |
 | py36-1.16-1_0.7.3 | python         | von-image:py36-1.16-1 | 0.7.3            |
-| py36-1.16-1_0.7.4-rc0 | python     | von-image:py36-1.16-1 | 0.7.4-rc0        |
-| py36-1.16-1_0.7.4-rc1 | python     | von-image:py36-1.16-1 | 0.7.4-rc1        |
-| py36-1.16-1_0.7.4-rc2 | python     | von-image:py36-1.16-1 | 0.7.4-rc2        |
-| py36-1.16-1_0.7.4-rc3 | python     | von-image:py36-1.16-1 | 0.7.4-rc3        |
-| py36-1.16-1_0.7.4-rc4 | python     | von-image:py36-1.16-1 | 0.7.4-rc4        |
-| py36-1.16-1_0.7.4-rc5 | python     | von-image:py36-1.16-1 | 0.7.4-rc5        |
+| py36-1.16-1_0.7.4 | python         | von-image:py36-1.16-1 | 0.7.4            |
 
 # Building the image locally
 

--- a/make_image.py
+++ b/make_image.py
@@ -144,21 +144,7 @@ VERSIONS = {
             },
         },
         {
-            "version": "0.7.2-rc0",
-            "args": {
-                "base_image": "bcgovimages/von-image:py36-1.16-1",
-                "acapy_reqs": "[askar,bbs]"
-            },
-        },
-        {
             "version": "0.7.2",
-            "args": {
-                "base_image": "bcgovimages/von-image:py36-1.16-1",
-                "acapy_reqs": "[askar,bbs]"
-            },
-        },
-        {
-            "version": "0.7.3-rc0",
             "args": {
                 "base_image": "bcgovimages/von-image:py36-1.16-1",
                 "acapy_reqs": "[askar,bbs]"
@@ -172,42 +158,7 @@ VERSIONS = {
             },
         },
         {
-            "version": "0.7.4-rc0",
-            "args": {
-                "base_image": "bcgovimages/von-image:py36-1.16-1",
-                "acapy_reqs": "[askar,bbs]"
-            },
-        },
-        {
-            "version": "0.7.4-rc1",
-            "args": {
-                "base_image": "bcgovimages/von-image:py36-1.16-1",
-                "acapy_reqs": "[askar,bbs]"
-            },
-        },
-        {
-            "version": "0.7.4-rc2",
-            "args": {
-                "base_image": "bcgovimages/von-image:py36-1.16-1",
-                "acapy_reqs": "[askar,bbs]"
-            },
-        },
-        {
-            "version": "0.7.4-rc3",
-            "args": {
-                "base_image": "bcgovimages/von-image:py36-1.16-1",
-                "acapy_reqs": "[askar,bbs]"
-            },
-        },
-        {
-            "version": "0.7.4-rc4",
-            "args": {
-                "base_image": "bcgovimages/von-image:py36-1.16-1",
-                "acapy_reqs": "[askar,bbs]"
-            },
-        },
-        {
-            "version": "0.7.4-rc5",
+            "version": "0.7.4",
             "args": {
                 "base_image": "bcgovimages/von-image:py36-1.16-1",
                 "acapy_reqs": "[askar,bbs]"


### PR DESCRIPTION
@WadeBarnes -- note the cleanup/removal of the RC tags for 0.7.4 and the previous releases.  I think that is appropriate, but definitely want to get your opinion. I can revert if you want.  We can easily still recreate the RC images if we need to, and have the history.  I just don't think they should continue in the file.